### PR TITLE
add check for existence of CMB class function …

### DIFF
--- a/cgit-wp-cmb-ukdate.php
+++ b/cgit-wp-cmb-ukdate.php
@@ -42,7 +42,10 @@ register_activation_hook(__FILE__, 'cgit_wp_cmb_ukdate_activate');
  * Check that CustomMetaBoxes plugin is installed
  */
 function cgit_wp_cmb_ukdate_check_cmb() {
-    return is_plugin_active('Custom-Meta-Boxes/custom-meta-boxes.php');
+  if(!is_plugin_active('Custom-Meta-Boxes/custom-meta-boxes.php') && !class_exists('CMB_Meta_Box')){
+      return false;
+  }
+  return true;
 }
 
 

--- a/cgit-wp-cmb-ukdate.php
+++ b/cgit-wp-cmb-ukdate.php
@@ -43,8 +43,11 @@ register_activation_hook(__FILE__, 'cgit_wp_cmb_ukdate_activate');
  */
 function cgit_wp_cmb_ukdate_check_cmb() {
   if(!is_plugin_active('Custom-Meta-Boxes/custom-meta-boxes.php') && !class_exists('CMB_Meta_Box')){
+
       return false;
+
   }
+  
   return true;
 }
 


### PR DESCRIPTION
…cgit_wp_cmb_ukdate_check_cmb to allow for cases where CMB is not used as a plugin.

We don't use the CMB library as a plugin, but the UK date plugin doesn't allow for this and only checks the existence of the plugin not the instantiation of the class. I have added a class_exists check to the function which checks for the plugin existence, so the plugin works in this scenario.